### PR TITLE
refactor(markdownlint): remove inline HTML allowance

### DIFF
--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -29,7 +29,6 @@ MD026:
   punctuation: ".,;:!。，；:" # List of not allowed
 MD029: false # Ordered list item prefix
 MD030: false
-MD033: false # Allow inline HTML
 MD036: false # Emphasis used instead of a heading
 MD049: false # emphasis-style Emphasis style should be consistent
 


### PR DESCRIPTION
If we would like to add specific tags in the future, we could so via a whitelist from now on: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html