### PR TITLE
refactor: new timing for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "04:00"
+      time: "02:00"
       timezone: "Europe/Berlin"
     pull-request-branch-name:
       separator: "-"
@@ -16,7 +16,7 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-      time: "04:00"
+      time: "02:00"
       timezone: "Europe/Berlin"
     ignore:
       - dependency-name: "ng-packagr"
@@ -57,7 +57,7 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-      time: "04:00"
+      time: "02:00"
       timezone: "Europe/Berlin"
     pull-request-branch-name:
       separator: "-"
@@ -68,7 +68,7 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-      time: "04:00"
+      time: "02:00"
       timezone: "Europe/Berlin"
     pull-request-branch-name:
       separator: "-"


### PR DESCRIPTION
re-timed the dependabot update checks as they might take a little longer especially due to the missing grouping possibility.