### PR TITLE
refactor(style): both simplifying and extending inherit declarations

### DIFF
--- a/packages/foundations/scss/_init.scss
+++ b/packages/foundations/scss/_init.scss
@@ -47,9 +47,10 @@ button,
 input,
 select,
 textarea {
-	font-family: inherit;
-	font-size: inherit;
-	line-height: inherit;
+	// Adapted from https://adrianroselli.com/2021/03/under-engineered-select-menus.html
+	font: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }
 
 // Media


### PR DESCRIPTION
To inherit font related declarations in total, we could only use the shorthand `font` to inherit from. Additionally we most likely even also want to inherit `letter-` and `word-spacing`.

Adapted from https://adrianroselli.com/2021/03/under-engineered-select-menus.html