### PR TITLE
fix: generate components template

### DIFF
--- a/packages/components/_templates/mitosis/new/react-showcase-component.ejs.t
+++ b/packages/components/_templates/mitosis/new/react-showcase-component.ejs.t
@@ -3,7 +3,7 @@ to: ../../showcases/react-showcase/src/components/<%= name %>/index.tsx
 ---
 import { DB<%= h.changeCase.pascal(name) %> } from '../../../../../output/react/src';
 import DefaultComponent from '../index';
-import type { type DefaultComponentVariants } from '../data';
+import type { DefaultComponentVariants } from '../data';
 
 const variants: DefaultComponentVariants[] = [];
 


### PR DESCRIPTION
this declaration lead to an error during build:
> The 'type' modifier cannot be used on a named import when 'import type' is used on its import statement. (3:14)