### PR TITLE
fix: selector on new pseudo-selector

### DIFF
--- a/packages/components/src/components/radio/radio.scss
+++ b/packages/components/src/components/radio/radio.scss
@@ -40,7 +40,7 @@ $font-size-height: calc(var(--db-base-font-size) * var(--db-base-line-height));
 
 	// * The invalid style using the :user-invalid pseudo class (and [aria-invalid="true"] equivalent)
 	// TODO: We need to set the correct styling / color here after alignment
-	&:user-invalid,
+	&:is(:user-invalid),
 	&[aria-invalid="true"] {
 		@extend %db-bg-critical-transparent-semi;
 		@extend %db-bg-critical-transparent-semi-hover-state;


### PR DESCRIPTION
`:user-invalid` selector will soon get supported by all evergreen browsers, but we need to ensure that those aren't conflicting with non-supporting browsers.