### PR TITLE
refactor(link): simplified icon reference

### DIFF
--- a/packages/components/src/components/link/link.lite.tsx
+++ b/packages/components/src/components/link/link.lite.tsx
@@ -1,5 +1,4 @@
 import { onMount, Show, useMetadata, useStore } from '@builder.io/mitosis';
-import { DBIcon } from '../icon';
 import { DBLinkState, DBLinkProps } from './model';
 
 useMetadata({
@@ -50,13 +49,6 @@ export default function DBLink(props: DBLinkProps) {
 				<link rel="stylesheet" href={state.stylePath} />
 			</Show>
 			{props.children}
-			<Show when={props.variant !== 'inline'}>
-				<DBIcon
-					icon={
-						props.content == 'external' ? 'link-external' : 'link'
-					}
-					icntxt={true}></DBIcon>
-			</Show>
 		</a>
 	);
 }

--- a/packages/components/src/components/link/link.scss
+++ b/packages/components/src/components/link/link.scss
@@ -11,7 +11,6 @@
 .db-link {
 	@extend %default-color;
 	width: fit-content;
-	display: flex;
 	align-items: center;
 	border-radius: to-rem($pxValue: 6);
 
@@ -52,8 +51,7 @@
 			outline-offset: var(--db-focus-outline-offset, 1px);
 		}
 
-		&::after,
-		.db-icon {
+		&::after {
 			--icon-margin-before: var(--db-spacing-fixed-2xs);
 			margin-inline-start: var(--icon-margin-before);
 		}
@@ -69,16 +67,11 @@
 
 		&[data-content="internal"],
 		&[data-content="external"] {
-			&::after,
-			.db-icon {
+			&::after {
 				--icon-margin-before: var(--db-spacing-fixed-3xs);
 				--icon-font-size: var(--db-base-icon-font-size);
 				@extend %db-body-sm;
 			}
 		}
-	}
-
-	.db-icon {
-		display: inline;
 	}
 }

--- a/packages/components/src/components/link/link.scss
+++ b/packages/components/src/components/link/link.scss
@@ -34,11 +34,6 @@
 		pointer-events: none;
 	}
 
-	&[data-content] {
-		--icon-font-family: var(--db-base-icon-font-family);
-		--icon-font-size: var(--db-base-icon-font-size);
-	}
-
 	&[data-content="internal"] {
 		@include icon(glyph(arrow-forward), 24, "outline", "after");
 	}


### PR DESCRIPTION
Those styling related declarations are included within SCSS and won't need it within markup at all.

Must get merged after: https://github.com/db-ui/mono/pull/799