### PR TITLE
refactor: rolled back xo version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # We currently need to ignore this until we migrate to TypeScript 5
+      - dependency-name: "xo"
+        update-types: ["version-update:semver-minor"]
       # We currently need to ignore this for the actual (LTS) Angular version
       - dependency-name: "zone.js"
         update-types: ["version-update:semver-minor"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "tslib": "^2.5.0",
         "typescript": "^4.9.5",
         "validate-branch-name": "^1.3.0",
-        "xo": "^0.54.1"
+        "xo": "^0.53.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9865,6 +9865,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
+      "dev": true
+    },
     "node_modules/clean-css": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
@@ -12539,25 +12545,35 @@
       }
     },
     "node_modules/eslint-formatter-pretty": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-5.0.0.tgz",
-      "integrity": "sha512-Uick451FoL22/wXqyScX3inW8ZlD/GQO7eFXj3bqb6N/ZtuuF00/CwSNIKLbFCJPrX5V4EdQBSgJ/UVnmLRnug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
       "dev": true,
       "dependencies": {
-        "@types/eslint": "^8.0.0",
+        "@types/eslint": "^7.2.13",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.0",
-        "eslint-rule-docs": "^1.1.235",
+        "eslint-rule-docs": "^1.1.5",
         "log-symbols": "^4.0.0",
         "plur": "^4.0.0",
         "string-width": "^4.2.0",
         "supports-hyperlinks": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
       }
     },
     "node_modules/eslint-formatter-pretty/node_modules/ansi-escapes": {
@@ -12777,9 +12793,9 @@
       }
     },
     "node_modules/eslint-plugin-ava": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-14.0.0.tgz",
-      "integrity": "sha512-XmKT6hppaipwwnLVwwvQliSU6AF1QMHiNoLD5JQfzhUhf0jY7CO0O624fQrE+Y/fTb9vbW8r77nKf7M/oHulxw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+      "integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
       "dev": true,
       "dependencies": {
         "enhance-visitors": "^1.0.0",
@@ -12792,10 +12808,10 @@
         "resolve-from": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.17 <15 || >=16.4"
+        "node": ">=12.22 <13 || >=14.17 <15 || >=16.4"
       },
       "peerDependencies": {
-        "eslint": ">=8.26.0"
+        "eslint": ">=7.22.0"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -13123,26 +13139,24 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "46.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-46.0.0.tgz",
-      "integrity": "sha512-j07WkC+PFZwk8J33LYp6JMoHa1lXc1u6R45pbSAipjpfpb7KIGr17VE2D685zCxR5VL4cjrl65kTJflziQWMDA==",
+      "version": "44.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
+      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@eslint-community/eslint-utils": "^4.1.2",
-        "ci-info": "^3.6.1",
+        "ci-info": "^3.4.0",
         "clean-regexp": "^1.0.0",
+        "eslint-utils": "^3.0.0",
         "esquery": "^1.4.0",
         "indent-string": "^4.0.0",
         "is-builtin-module": "^3.2.0",
-        "jsesc": "^3.0.2",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
         "regexp-tree": "^0.1.24",
-        "regjsparser": "^0.9.1",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.8",
+        "semver": "^7.3.7",
         "strip-indent": "^3.0.0"
       },
       "engines": {
@@ -13152,34 +13166,7 @@
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=8.28.0"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "eslint": ">=8.23.1"
       }
     },
     "node_modules/eslint-rule-docs": {
@@ -28435,9 +28422,9 @@
       }
     },
     "node_modules/to-absolute-glob": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-3.0.0.tgz",
-      "integrity": "sha512-loO/XEWTRqpfcpI7+Jr2RR2Umaaozx1t6OSVWtMi0oy5F/Fxg3IC+D/TToDnxyAGs7uZBGT/6XmyDUxgsObJXA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha512-rtwLUQEwT8ZeKQbyFJyomBRYXyE16U5VKuy0ftxLMK/PZb2fkOsg5r9kHdauuVDbsNdIBoC/HCthpidamQFXYA==",
       "dev": true,
       "dependencies": {
         "is-absolute": "^1.0.0",
@@ -30534,9 +30521,9 @@
       }
     },
     "node_modules/xo": {
-      "version": "0.54.1",
-      "resolved": "https://registry.npmjs.org/xo/-/xo-0.54.1.tgz",
-      "integrity": "sha512-6nrHpbVAnWL7w9HbfwosxhOb2iO8WUdds0xDYbJqTFAUUD1aUsRwY8Mt4gH/Vt4uUtCWzJtjb/fjWOLEOKfd3A==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/xo/-/xo-0.53.1.tgz",
+      "integrity": "sha512-/2R8SPehv1UhiIqJ9uSvrAjslcoygICNsUlEb/Zf2V6rMtr7YCoggc6hlt6b/kbncpR989Roqt6AvEO779dFxw==",
       "bundleDependencies": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
@@ -30545,41 +30532,41 @@
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
-        "@typescript-eslint/eslint-plugin": "^5.57.1",
-        "@typescript-eslint/parser": "^5.57.1",
+        "@typescript-eslint/eslint-plugin": "^5.43.0",
+        "@typescript-eslint/parser": "^5.43.0",
         "arrify": "^3.0.0",
-        "cosmiconfig": "^8.1.3",
+        "cosmiconfig": "^7.1.0",
         "define-lazy-prop": "^3.0.0",
-        "eslint": "^8.37.0",
-        "eslint-config-prettier": "^8.8.0",
+        "eslint": "^8.27.0",
+        "eslint-config-prettier": "^8.5.0",
         "eslint-config-xo": "^0.43.1",
-        "eslint-config-xo-typescript": "^0.57.0",
-        "eslint-formatter-pretty": "^5.0.0",
+        "eslint-config-xo-typescript": "^0.55.0",
+        "eslint-formatter-pretty": "^4.1.0",
         "eslint-import-resolver-webpack": "^0.13.2",
-        "eslint-plugin-ava": "^14.0.0",
+        "eslint-plugin-ava": "^13.2.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-n": "^15.7.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.5.1",
         "eslint-plugin-no-use-extend-native": "^0.5.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-unicorn": "^46.0.0",
-        "esm-utils": "^4.1.2",
+        "eslint-plugin-unicorn": "^44.0.2",
+        "esm-utils": "^4.1.0",
         "find-cache-dir": "^4.0.0",
         "find-up": "^6.3.0",
         "get-stdin": "^9.0.0",
-        "get-tsconfig": "^4.5.0",
         "globby": "^13.1.2",
         "imurmurhash": "^0.1.4",
         "json-stable-stringify-without-jsonify": "^1.0.1",
+        "json5": "^2.2.1",
         "lodash-es": "^4.17.21",
         "meow": "^11.0.0",
         "micromatch": "^4.0.5",
         "open-editor": "^4.0.0",
-        "prettier": "^2.8.7",
+        "prettier": "^2.7.1",
         "semver": "^7.3.8",
         "slash": "^5.0.0",
-        "to-absolute-glob": "^3.0.0",
-        "typescript": "^5.0.3"
+        "to-absolute-glob": "^2.0.2",
+        "typescript": "^4.9.3"
       },
       "bin": {
         "xo": "cli.js"
@@ -30589,30 +30576,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xo/node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
-    },
-    "node_modules/xo/node_modules/@eslint-community/regexpp": {
-      "version": "4.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/xo/node_modules/@eslint/eslintrc": {
@@ -30686,19 +30649,18 @@
       "license": "MIT"
     },
     "node_modules/xo/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/type-utils": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
@@ -30720,14 +30682,14 @@
       }
     },
     "node_modules/xo/node_modules/@typescript-eslint/parser": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -30747,13 +30709,13 @@
       }
     },
     "node_modules/xo/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -30764,13 +30726,13 @@
       }
     },
     "node_modules/xo/node_modules/@typescript-eslint/type-utils": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -30791,7 +30753,7 @@
       }
     },
     "node_modules/xo/node_modules/@typescript-eslint/types": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -30804,13 +30766,13 @@
       }
     },
     "node_modules/xo/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -30860,18 +30822,18 @@
       }
     },
     "node_modules/xo/node_modules/@typescript-eslint/utils": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -30886,12 +30848,12 @@
       }
     },
     "node_modules/xo/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
+      "version": "5.43.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/types": "5.43.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -30993,6 +30955,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xo/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/xo/node_modules/debug": {
       "version": "4.3.4",
       "dev": true,
@@ -31053,7 +31031,7 @@
       }
     },
     "node_modules/xo/node_modules/eslint-config-xo-typescript": {
-      "version": "0.57.0",
+      "version": "0.55.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -31064,8 +31042,8 @@
         "url": "https://github.com/sponsors/sindresorhus"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">=5.57.0",
-        "@typescript-eslint/parser": ">=5.57.0",
+        "@typescript-eslint/eslint-plugin": ">=5.43.0",
+        "@typescript-eslint/parser": ">=5.43.0",
         "eslint": ">=8.0.0",
         "typescript": ">=4.4"
       }
@@ -31092,16 +31070,40 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xo/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/xo/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/xo/node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
+      "version": "3.3.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/xo/node_modules/esrecurse": {
@@ -31142,7 +31144,7 @@
       }
     },
     "node_modules/xo/node_modules/fastq": {
-      "version": "1.15.0",
+      "version": "1.13.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -31221,12 +31223,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/xo/node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/xo/node_modules/hosted-git-info": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
@@ -31249,7 +31245,7 @@
       }
     },
     "node_modules/xo/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -31304,6 +31300,18 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/xo/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/xo/node_modules/locate-path": {
       "version": "7.2.0",
@@ -31583,6 +31591,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xo/node_modules/regexpp": {
+      "version": "3.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/xo/node_modules/reusify": {
       "version": "1.0.4",
       "dev": true,
@@ -31617,7 +31637,7 @@
       }
     },
     "node_modules/xo/node_modules/semver": {
-      "version": "7.4.0",
+      "version": "7.3.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -31642,12 +31662,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/xo/node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/xo/node_modules/slash": {
       "version": "5.0.0",
@@ -31733,19 +31747,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/xo/node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+    "node_modules/xo/node_modules/yallist": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=12.20"
-      }
+      "license": "ISC"
     },
     "node_modules/xo/node_modules/yargs-parser": {
       "version": "21.1.1",
@@ -33602,6 +33608,7 @@
         "@builder.io/mitosis": "^0.0.96",
         "@builder.io/mitosis-cli": "^0.0.55",
         "@react-docgen/cli": "^1.0.0-alpha.1",
+        "classnames": "^2.3.2",
         "cpr": "3.0.1",
         "eslint": "^8.38.0",
         "hygen": "^6.2.11",
@@ -39690,6 +39697,7 @@
         "@builder.io/mitosis-cli": "^0.0.55",
         "@db-ui/foundations": "*",
         "@react-docgen/cli": "^1.0.0-alpha.1",
+        "classnames": "^2.3.2",
         "cpr": "3.0.1",
         "eslint": "^8.38.0",
         "hygen": "^6.2.11",
@@ -47529,6 +47537,12 @@
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true
     },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
+      "dev": true
+    },
     "clean-css": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
@@ -49538,21 +49552,31 @@
       }
     },
     "eslint-formatter-pretty": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-5.0.0.tgz",
-      "integrity": "sha512-Uick451FoL22/wXqyScX3inW8ZlD/GQO7eFXj3bqb6N/ZtuuF00/CwSNIKLbFCJPrX5V4EdQBSgJ/UVnmLRnug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
       "dev": true,
       "requires": {
-        "@types/eslint": "^8.0.0",
+        "@types/eslint": "^7.2.13",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.0",
-        "eslint-rule-docs": "^1.1.235",
+        "eslint-rule-docs": "^1.1.5",
         "log-symbols": "^4.0.0",
         "plur": "^4.0.0",
         "string-width": "^4.2.0",
         "supports-hyperlinks": "^2.0.0"
       },
       "dependencies": {
+        "@types/eslint": {
+          "version": "7.29.0",
+          "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+          "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "*",
+            "@types/json-schema": "*"
+          }
+        },
         "ansi-escapes": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -49719,9 +49743,9 @@
       }
     },
     "eslint-plugin-ava": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-14.0.0.tgz",
-      "integrity": "sha512-XmKT6hppaipwwnLVwwvQliSU6AF1QMHiNoLD5JQfzhUhf0jY7CO0O624fQrE+Y/fTb9vbW8r77nKf7M/oHulxw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+      "integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
       "dev": true,
       "requires": {
         "enhance-visitors": "^1.0.0",
@@ -49967,44 +49991,25 @@
       "requires": {}
     },
     "eslint-plugin-unicorn": {
-      "version": "46.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-46.0.0.tgz",
-      "integrity": "sha512-j07WkC+PFZwk8J33LYp6JMoHa1lXc1u6R45pbSAipjpfpb7KIGr17VE2D685zCxR5VL4cjrl65kTJflziQWMDA==",
+      "version": "44.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
+      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@eslint-community/eslint-utils": "^4.1.2",
-        "ci-info": "^3.6.1",
+        "ci-info": "^3.4.0",
         "clean-regexp": "^1.0.0",
+        "eslint-utils": "^3.0.0",
         "esquery": "^1.4.0",
         "indent-string": "^4.0.0",
         "is-builtin-module": "^3.2.0",
-        "jsesc": "^3.0.2",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
         "regexp-tree": "^0.1.24",
-        "regjsparser": "^0.9.1",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.8",
+        "semver": "^7.3.7",
         "strip-indent": "^3.0.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-          "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "eslint-rule-docs": {
@@ -61296,9 +61301,9 @@
       }
     },
     "to-absolute-glob": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-3.0.0.tgz",
-      "integrity": "sha512-loO/XEWTRqpfcpI7+Jr2RR2Umaaozx1t6OSVWtMi0oy5F/Fxg3IC+D/TToDnxyAGs7uZBGT/6XmyDUxgsObJXA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha512-rtwLUQEwT8ZeKQbyFJyomBRYXyE16U5VKuy0ftxLMK/PZb2fkOsg5r9kHdauuVDbsNdIBoC/HCthpidamQFXYA==",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -62853,62 +62858,49 @@
       "dev": true
     },
     "xo": {
-      "version": "0.54.1",
-      "resolved": "https://registry.npmjs.org/xo/-/xo-0.54.1.tgz",
-      "integrity": "sha512-6nrHpbVAnWL7w9HbfwosxhOb2iO8WUdds0xDYbJqTFAUUD1aUsRwY8Mt4gH/Vt4uUtCWzJtjb/fjWOLEOKfd3A==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/xo/-/xo-0.53.1.tgz",
+      "integrity": "sha512-/2R8SPehv1UhiIqJ9uSvrAjslcoygICNsUlEb/Zf2V6rMtr7YCoggc6hlt6b/kbncpR989Roqt6AvEO779dFxw==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
-        "@typescript-eslint/eslint-plugin": "^5.57.1",
-        "@typescript-eslint/parser": "^5.57.1",
+        "@typescript-eslint/eslint-plugin": "^5.43.0",
+        "@typescript-eslint/parser": "^5.43.0",
         "arrify": "^3.0.0",
-        "cosmiconfig": "^8.1.3",
+        "cosmiconfig": "^7.1.0",
         "define-lazy-prop": "^3.0.0",
-        "eslint": "^8.37.0",
-        "eslint-config-prettier": "^8.8.0",
+        "eslint": "^8.27.0",
+        "eslint-config-prettier": "^8.5.0",
         "eslint-config-xo": "^0.43.1",
-        "eslint-config-xo-typescript": "^0.57.0",
-        "eslint-formatter-pretty": "^5.0.0",
+        "eslint-config-xo-typescript": "^0.55.0",
+        "eslint-formatter-pretty": "^4.1.0",
         "eslint-import-resolver-webpack": "^0.13.2",
-        "eslint-plugin-ava": "^14.0.0",
+        "eslint-plugin-ava": "^13.2.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-n": "^15.7.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.5.1",
         "eslint-plugin-no-use-extend-native": "^0.5.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-unicorn": "^46.0.0",
-        "esm-utils": "^4.1.2",
+        "eslint-plugin-unicorn": "^44.0.2",
+        "esm-utils": "^4.1.0",
         "find-cache-dir": "^4.0.0",
         "find-up": "^6.3.0",
         "get-stdin": "^9.0.0",
-        "get-tsconfig": "^4.5.0",
         "globby": "^13.1.2",
         "imurmurhash": "^0.1.4",
         "json-stable-stringify-without-jsonify": "^1.0.1",
+        "json5": "^2.2.1",
         "lodash-es": "^4.17.21",
         "meow": "^11.0.0",
         "micromatch": "^4.0.5",
         "open-editor": "^4.0.0",
-        "prettier": "^2.8.7",
+        "prettier": "^2.7.1",
         "semver": "^7.3.8",
         "slash": "^5.0.0",
-        "to-absolute-glob": "^3.0.0",
-        "typescript": "^5.0.3"
+        "to-absolute-glob": "^2.0.2",
+        "typescript": "^4.9.3"
       },
       "dependencies": {
-        "@eslint-community/eslint-utils": {
-          "version": "4.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        },
-        "@eslint-community/regexpp": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
         "@eslint/eslintrc": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -62960,65 +62952,64 @@
           "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@eslint-community/regexpp": "^4.4.0",
-            "@typescript-eslint/scope-manager": "5.58.0",
-            "@typescript-eslint/type-utils": "5.58.0",
-            "@typescript-eslint/utils": "5.58.0",
+            "@typescript-eslint/scope-manager": "5.43.0",
+            "@typescript-eslint/type-utils": "5.43.0",
+            "@typescript-eslint/utils": "5.43.0",
             "debug": "^4.3.4",
-            "grapheme-splitter": "^1.0.4",
             "ignore": "^5.2.0",
             "natural-compare-lite": "^1.4.0",
+            "regexpp": "^3.2.0",
             "semver": "^7.3.7",
             "tsutils": "^3.21.0"
           }
         },
         "@typescript-eslint/parser": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "5.58.0",
-            "@typescript-eslint/types": "5.58.0",
-            "@typescript-eslint/typescript-estree": "5.58.0",
+            "@typescript-eslint/scope-manager": "5.43.0",
+            "@typescript-eslint/types": "5.43.0",
+            "@typescript-eslint/typescript-estree": "5.43.0",
             "debug": "^4.3.4"
           }
         },
         "@typescript-eslint/scope-manager": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.58.0",
-            "@typescript-eslint/visitor-keys": "5.58.0"
+            "@typescript-eslint/types": "5.43.0",
+            "@typescript-eslint/visitor-keys": "5.43.0"
           }
         },
         "@typescript-eslint/type-utils": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@typescript-eslint/typescript-estree": "5.58.0",
-            "@typescript-eslint/utils": "5.58.0",
+            "@typescript-eslint/typescript-estree": "5.43.0",
+            "@typescript-eslint/utils": "5.43.0",
             "debug": "^4.3.4",
             "tsutils": "^3.21.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.58.0",
-            "@typescript-eslint/visitor-keys": "5.58.0",
+            "@typescript-eslint/types": "5.43.0",
+            "@typescript-eslint/visitor-keys": "5.43.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -63047,26 +63038,26 @@
           }
         },
         "@typescript-eslint/utils": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@eslint-community/eslint-utils": "^4.2.0",
             "@types/json-schema": "^7.0.9",
             "@types/semver": "^7.3.12",
-            "@typescript-eslint/scope-manager": "5.58.0",
-            "@typescript-eslint/types": "5.58.0",
-            "@typescript-eslint/typescript-estree": "5.58.0",
+            "@typescript-eslint/scope-manager": "5.43.0",
+            "@typescript-eslint/types": "5.43.0",
+            "@typescript-eslint/typescript-estree": "5.43.0",
             "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0",
             "semver": "^7.3.7"
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.58.0",
+          "version": "5.43.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.58.0",
+            "@typescript-eslint/types": "5.43.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -63127,6 +63118,19 @@
             }
           }
         },
+        "cosmiconfig": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+          "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
         "debug": {
           "version": "4.3.4",
           "bundled": true,
@@ -63163,7 +63167,7 @@
           }
         },
         "eslint-config-xo-typescript": {
-          "version": "0.57.0",
+          "version": "0.55.0",
           "bundled": true,
           "dev": true,
           "requires": {}
@@ -63184,8 +63188,23 @@
             }
           }
         },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
         "eslint-visitor-keys": {
-          "version": "3.4.0",
+          "version": "3.3.0",
           "bundled": true,
           "dev": true
         },
@@ -63215,7 +63234,7 @@
           }
         },
         "fastq": {
-          "version": "1.15.0",
+          "version": "1.13.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63269,11 +63288,6 @@
             }
           }
         },
-        "grapheme-splitter": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
         "hosted-git-info": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
@@ -63292,7 +63306,7 @@
           }
         },
         "ignore": {
-          "version": "5.2.4",
+          "version": "5.2.0",
           "bundled": true,
           "dev": true
         },
@@ -63324,6 +63338,12 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
           "dev": true
         },
         "locate-path": {
@@ -63501,6 +63521,11 @@
             "strip-indent": "^4.0.0"
           }
         },
+        "regexpp": {
+          "version": "3.2.0",
+          "bundled": true,
+          "dev": true
+        },
         "reusify": {
           "version": "1.0.4",
           "bundled": true,
@@ -63515,7 +63540,7 @@
           }
         },
         "semver": {
-          "version": "7.4.0",
+          "version": "7.3.8",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63529,11 +63554,6 @@
               "requires": {
                 "yallist": "^4.0.0"
               }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -63585,10 +63605,8 @@
           "integrity": "sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==",
           "dev": true
         },
-        "typescript": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-          "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+        "yallist": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "tslib": "^2.5.0",
     "typescript": "^4.9.5",
     "validate-branch-name": "^1.3.0",
-    "xo": "^0.54.1"
+    "xo": "^0.53.1"
   },
   "validate-branch-name": {
     "pattern": "((dbux-3)|(dependabot-)|^((test|feat|fix|chore|docs|refactor|style|ci|perf|[0-9]+)\\-[a-zA-Z0-9\\-]+)$)",


### PR DESCRIPTION
We're currently facing conflicts within the lock file due to [TypeScript being expected in version 5 by `xo`](https://github.com/db-ui/mono/pull/802), but most of our other dependencies still use version 4.