### PR TITLE
fix: type warning feedback

### DIFF
--- a/packages/components/src/components/alert/alert.lite.tsx
+++ b/packages/components/src/components/alert/alert.lite.tsx
@@ -52,7 +52,7 @@ export default function DBAlert(props: DBAlertProps) {
 			return (variant && DefaultVariantsIcon[variant]) || 'info';
 		},
 		iconVisible: (icon?: string) => {
-			return icon && icon !== '_' && icon !== 'none';
+			return Boolean(icon && icon !== '_' && icon !== 'none');
 		}
 	});
 

--- a/packages/components/src/components/button/button.lite.tsx
+++ b/packages/components/src/components/button/button.lite.tsx
@@ -55,7 +55,7 @@ export default function DBButton(props: DBButtonProps) {
 			}
 		},
 		iconVisible: (icon?: string) => {
-			return icon && icon !== '_' && icon !== 'none';
+			return Boolean(icon && icon !== '_' && icon !== 'none');
 		}
 	});
 

--- a/packages/components/src/components/input/input.lite.tsx
+++ b/packages/components/src/components/input/input.lite.tsx
@@ -43,7 +43,7 @@ export default function DBInput(props: DBInputProps) {
 		_isValid: undefined,
 		_value: '',
 		iconVisible: (icon?: string) => {
-			return icon && icon !== '_' && icon !== 'none';
+			return Boolean(icon && icon !== '_' && icon !== 'none');
 		},
 		getIcon: (variant?: DefaultVariantProps) => {
 			if (variant) {


### PR DESCRIPTION
```
(property) iconVisible: (icon?: string | undefined) => boolean
Type '(icon?: string) => boolean | "" | undefined' is not assignable to type '(icon?: string | undefined) => boolean'.
  Type 'string | boolean | undefined' is not assignable to type 'boolean'.
    Type 'undefined' is not assignable to type 'boolean'.ts(2322)
model.ts(34, 2): The expected type comes from property 'iconVisible' which is declared here on type 'DBAlertState'
```