### PR TITLE
refactor: generalizing some states

### DIFF
--- a/packages/components/src/components/input/input.lite.tsx
+++ b/packages/components/src/components/input/input.lite.tsx
@@ -129,6 +129,7 @@ export default function DBInput(props: DBInputProps) {
 				disabled={props.disabled}
 				required={props.required}
 				value={state._value}
+				aria-invalid={props.invalid}
 				maxLength={props.maxLength}
 				minLength={props.minLength}
 				pattern={props.pattern}

--- a/packages/components/src/components/radio/model.ts
+++ b/packages/components/src/components/radio/model.ts
@@ -14,7 +14,6 @@ import {
 export interface DBRadioDefaultProps {
 	checked?: boolean;
 	describedbyid?: string;
-	invalid?: boolean;
 	size?: 'small';
 }
 

--- a/packages/components/src/shared/model.ts
+++ b/packages/components/src/shared/model.ts
@@ -23,6 +23,11 @@ export type GlobalProps = {
 	id?: string;
 
 	/**
+	 * [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) is used to link to the elements that describe the element with the set attribute.
+	 */
+	describedbyid?: string;
+
+	/**
 	 * Web Component specific: Adds a link tag with the path to show css inside Shadow DOM.
 	 */
 	stylePath?: string;

--- a/packages/components/src/shared/model.ts
+++ b/packages/components/src/shared/model.ts
@@ -81,6 +81,7 @@ export type FormProps = {
 	required?: boolean;
 	value?: any;
 	name?: string;
+	invalid?: boolean;
 };
 
 export type FormState = {


### PR DESCRIPTION
Resolves https://github.com/db-ui/mono/issues/870

- [x] added missing `aria-invalid` attribute to `input`
- [x] extracted `invalid` prop
- [x] added global `describedbyid` prop