### PR TITLE
chore: simplified selectors

### DIFF
--- a/packages/components/src/components/input/input.scss
+++ b/packages/components/src/components/input/input.scss
@@ -335,7 +335,7 @@
 
 			&:focus,
 			&:not(:placeholder-shown) {
-				&:not(:disabled) {
+				&:enabled {
 					+ label {
 						padding-inline-start: 0;
 					}

--- a/packages/components/src/components/radio/radio.scss
+++ b/packages/components/src/components/radio/radio.scss
@@ -32,7 +32,7 @@ $font-size-height: calc(var(--db-base-font-size) * var(--db-base-line-height));
 		border-width: calc(#{$font-size-height} * 0.3);
 
 		// The radio element still has the default background for the dot on :hover when in checked state
-		&:not(:disabled):hover {
+		&:enabled:hover {
 			@extend %bg-transparent;
 		}
 	}

--- a/packages/foundations/scripts/color-placeholders-generator.js
+++ b/packages/foundations/scripts/color-placeholders-generator.js
@@ -39,7 +39,7 @@ const generateInteractiveVariants = (
     			${primaryColor ? getRBGA(primaryColor, 'hover') : ''}
 			}`;
 	return `
-		&:not(:disabled) {
+		&:enabled {
 			${noHover ? '' : hoverState}
 			${noActive ? '' : activeState}
         }

--- a/packages/foundations/scss/color/_color-variants.scss
+++ b/packages/foundations/scss/color/_color-variants.scss
@@ -40,7 +40,7 @@ $color-variants: "neutral-0", "neutral-1", "neutral-3", "neutral-4", "primary",
 %bg-transparent-hover {
 	@extend %bg-transparent;
 
-	&:not(:disabled) {
+	&:enabled {
 		&:hover {
 			@include get-variant-bg-color(0.16);
 		}
@@ -50,7 +50,7 @@ $color-variants: "neutral-0", "neutral-1", "neutral-3", "neutral-4", "primary",
 %bg-transparent-interactive {
 	@extend %bg-transparent-hover;
 
-	&:not(:disabled) {
+	&:enabled {
 		&:active {
 			@include get-variant-bg-color(0.24);
 		}


### PR DESCRIPTION
It's simpler to not use the `:not` selector.