### PR TITLE
refactor(drawer): integrated feedback

### DIFF
--- a/packages/components/src/components/drawer/drawer.scss
+++ b/packages/components/src/components/drawer/drawer.scss
@@ -163,6 +163,12 @@ $spacings: (
 		}
 	}
 
+	&[data-backdrop="false"] {
+		.db-drawer-container {
+			box-shadow: $db-elevation-4;
+		}
+	}
+
 	&[open] {
 		.db-drawer-container {
 			&:not([data-direction]),


### PR DESCRIPTION
The opened "non full width" drawer without a backdrop needs some visual boundary on the "open" side – therefor we'll add a box-shadow of `elevation-4`.

<img width="690" alt="image" src="https://github.com/db-ui/mono/assets/787658/3704ee6b-6157-41c2-b109-656c1aefa3f8">
