### PR TITLE
feat: add "weak" emphasis for drawer

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,7 +5,7 @@
 	],
 	"plugins": ["stylelint-use-logical"],
 	"rules": {
-		"csstools/use-logical": "always",
+		"csstools/use-logical": ["always", { "except": ["float"] }],
 		"order/properties-alphabetical-order": null,
 		"scss/operator-no-newline-after": null,
 		"declaration-empty-line-before": null,

--- a/packages/components/src/components/drawer/drawer.lite.tsx
+++ b/packages/components/src/components/drawer/drawer.lite.tsx
@@ -10,7 +10,7 @@ import {
 import { DBDrawerState, DBDrawerProps } from './model';
 import { DBButton } from '../button';
 import { DEFAULT_CLOSE_BUTTON, DEFAULT_ID } from '../../shared/constants';
-import { cls } from "../../utils";
+import { cls } from '../../utils';
 import { uuid } from '../../utils';
 
 useMetadata({
@@ -90,7 +90,8 @@ export default function DBDrawer(props: DBDrawerProps) {
 				state.handleClose(event);
 			}}
 			onKeyDown={(event) => state.handleClose(event)}
-			data-backdrop={!props.noBackdrop}>
+			data-backdrop={!props.noBackdrop}
+			data-emphasis={props.emphasis}>
 			<Show when={state.stylePath}>
 				<link rel="stylesheet" href={state.stylePath} />
 			</Show>

--- a/packages/components/src/components/drawer/drawer.scss
+++ b/packages/components/src/components/drawer/drawer.scss
@@ -55,7 +55,7 @@
 
 %close-button-position {
 	margin-inline-start: $db-spacing-fixed-lg;
-	float: inline-end;
+	float: right;
 }
 
 $spacings: (

--- a/packages/components/src/components/drawer/model.ts
+++ b/packages/components/src/components/drawer/model.ts
@@ -13,6 +13,11 @@ export interface DBDrawerDefaultProps {
 	 * E. g. "left" slides from left screen border to the right.
 	 */
 	direction?: 'left' | 'right' | 'up' | 'down';
+
+	/**
+	 * The emphasis attribute changes the opacity of the backdrop.
+	 */
+	emphasis?: 'strong' | 'weak';
 	/**
 	 * If noBackdrop is set there is no semi-transparent black background behind the drawer.
 	 * You can click behind the drawer without closing it.
@@ -28,13 +33,13 @@ export interface DBDrawerDefaultProps {
 	 */
 	rounded?: boolean;
 	/**
-	 * The @dependabot recreate attribute changes the padding inside the drawer.
-	 */
-	spacing?: 'medium' | 'small' | 'large' | 'none';
-	/**
 	 * React specific to change the header of the drawer.
 	 */
 	slotDrawerHeader?: any;
+	/**
+	 * The @dependabot recreate attribute changes the padding inside the drawer.
+	 */
+	spacing?: 'medium' | 'small' | 'large' | 'none';
 
 	/**
 	 * The withCloseButton attribute shows/hides the default close button.

--- a/packages/components/src/styles/_dialog-init.scss
+++ b/packages/components/src/styles/_dialog-init.scss
@@ -1,5 +1,10 @@
 @use "@db-ui/foundations/build/scss/variables" as *;
 
+%backdrop {
+	background-color: $db-colors-neutral-on-bg-enabled;
+	opacity: 0.64;
+}
+
 %dialog-container {
 	position: fixed;
 	inset: 0;
@@ -12,14 +17,20 @@ dialog {
 	border: 0;
 	z-index: 9996;
 	color: inherit;
-}
 
-dialog[data-backdrop="false"] {
-	@extend %dialog-container;
-}
+	&[data-backdrop] {
+		@extend %dialog-container;
+	}
 
-dialog[data-backdrop="true"]::backdrop {
-	@extend %dialog-container;
-	background-color: $db-colors-neutral-on-bg-enabled;
-	opacity: 0.5;
+	&[data-backdrop="true"] {
+		&::backdrop {
+			@extend %backdrop;
+		}
+
+		&[data-emphasis="weak"] {
+			&::backdrop {
+				opacity: 0.32;
+			}
+		}
+	}
 }

--- a/showcases/react-showcase/src/components/drawer/index.tsx
+++ b/showcases/react-showcase/src/components/drawer/index.tsx
@@ -19,7 +19,8 @@ const getDrawer = ({
 	openDrawer,
 	setOpenDrawer,
 	direction,
-	children
+	children,
+	emphasis
 }: DBDrawerProps & AdditionalDrawerProps) => (
 	<div>
 		<DBDrawer
@@ -28,6 +29,7 @@ const getDrawer = ({
 			rounded={rounded}
 			width={width}
 			spacing={spacing}
+			emphasis={emphasis}
 			direction={direction}
 			open={openDrawer === id}
 			onClose={() => {

--- a/showcases/shared/drawer.json
+++ b/showcases/shared/drawer.json
@@ -38,6 +38,24 @@
 		]
 	},
 	{
+		"name": "Emphasis",
+		"examples": [
+			{
+				"name": "Strong (Default)",
+				"props": {
+					"withCloseButton": true
+				}
+			},
+			{
+				"name": "Weak",
+				"props": {
+					"withCloseButton": true,
+					"emphasis": "weak"
+				}
+			}
+		]
+	},
+	{
 		"name": "Rounded",
 		"examples": [
 			{


### PR DESCRIPTION
## Proposed changes

Add new attribute for `db-drawer`: `data-emphasis` to control the opacity of the background

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)