### PR TITLE
refactor(lint): added relevant ignore path to copy and paste linter

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -29,6 +29,7 @@
 		"**/README.md",
 		"**/generated/**",
 		"showcases/shared/*.json",
+		"showcases/patternhub/out/**",
 		"packages/components/src/components/alert/alert.lite.tsx",
 		"showcases/react-showcase/src/components/alert/index.tsx",
 		"packages/components/src/components/checkbox/checkbox.lite.tsx",


### PR DESCRIPTION
as this is an output path, we don't want to lint this one