### PR TITLE
refactor: doing markdownlint only for the staged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,4 +7,3 @@ npx validate-branch-name
 npm run scripts:check-commit-mail
 npx lint-staged --config ./.lintstagedrc
 npm run lint:jscpd
-npm run lint:markdownlint

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,5 @@
 {
+	"*.md": "markdownlint -c .markdown-lint.yml",
 	"*.{css,scss}": "stylelint --fix",
 	"*.{js,ts,tsx}": "xo --fix",
 	"!*.{js,ts,tsx}": "prettier --write --ignore-unknown"


### PR DESCRIPTION
Resolves https://github.com/db-ui/mono/issues/1432

I've tested this by checking in an invalid markdown file (and deactivating markdownlint just for that commit), and trying to commit another invalid file afterwards within another commit – within this commit response message out of `lint-staged`& `markdownlint`, only the newly checked in invalid file has been mentioned, whereas with the previous code both would have been mentioned.