### PR TITLE
refactor: next export is deprecated

### DIFF
--- a/showcases/patternhub/next.config.js
+++ b/showcases/patternhub/next.config.js
@@ -23,6 +23,7 @@ const withMDX = generated({
 });
 
 const config = {
+	output: 'export',
 	basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
 	transpilePackages: ['@db-ui'],
 	...withMDX({

--- a/showcases/patternhub/package.json
+++ b/showcases/patternhub/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "npm-run-all generate copy build:*",
-    "build:app": "next build && next export",
+    "build:app": "next build",
     "build:copy": "cpr out ../../build-showcases/patternhub -o",
     "copy": "npm-run-all copy:*",
     "copy:components": "cpr ../../output/react/src ./components/src -o",


### PR DESCRIPTION
the following warning gets logged:
> warn "next export" is deprecated in favor of "output: export" in next.config.js https://nextjs.org/docs/advanced-features/static-html-export