### PR TITLE
fix: popover font-style

### DIFF
--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -11,8 +11,6 @@ $tooltip-arrow-shadow-size: variables.$db-spacing-fixed-2xs;
 	@extend %db-overwrite-font-size-sm;
 	@extend %default-popover;
 
-	// i HTML tags browsers default styling reset
-	font-style: initial;
 	// surrounding tags styling reset
 	font-weight: initial;
 

--- a/packages/components/src/styles/_popover-component.scss
+++ b/packages/components/src/styles/_popover-component.scss
@@ -127,6 +127,7 @@
 	background-color: colors.$db-base-bg;
 	visibility: hidden;
 	z-index: 1;
+	// i HTML tags browsers default styling reset
 	font-style: normal;
 
 	&[data-width="fixed"] {

--- a/packages/components/src/styles/_popover-component.scss
+++ b/packages/components/src/styles/_popover-component.scss
@@ -127,6 +127,7 @@
 	background-color: colors.$db-base-bg;
 	visibility: hidden;
 	z-index: 1;
+	font-style: normal;
 
 	&[data-width="fixed"] {
 		inline-size: max-content;


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Add `font-style: normal;` for popover

Resolves https://github.com/db-ui/mono/issues/1761

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
