### PR TITLE
feat: add initOpenIndex to open accordion items initially

### DIFF
--- a/packages/components/src/components/accordion/accordion.lite.tsx
+++ b/packages/components/src/components/accordion/accordion.lite.tsx
@@ -79,9 +79,12 @@ export default function DBAccordion(props: DBAccordionProps) {
 			if (childDetails) {
 				let initOpenItems: string[] = [];
 				Array.from<HTMLDetailsElement>(childDetails).forEach(
-					(details: HTMLDetailsElement) => {
+					(details: HTMLDetailsElement, index: number) => {
 						const id = details.id;
-						if (details.open) {
+						if (
+							details.open ||
+							props.initOpenIndex.includes(index)
+						) {
 							initOpenItems.push(id);
 						}
 						const summaries =

--- a/packages/components/src/components/accordion/accordion.lite.tsx
+++ b/packages/components/src/components/accordion/accordion.lite.tsx
@@ -83,7 +83,7 @@ export default function DBAccordion(props: DBAccordionProps) {
 						const id = details.id;
 						if (
 							details.open ||
-							props.initOpenIndex.includes(index)
+							props.initOpenIndex?.includes(index)
 						) {
 							initOpenItems.push(id);
 						}

--- a/packages/components/src/components/accordion/model.ts
+++ b/packages/components/src/components/accordion/model.ts
@@ -10,6 +10,11 @@ export interface DBAccordionDefaultProps {
 	behaviour?: 'multiple' | 'single';
 
 	/**
+	 * The index of items which should be open when loading the accordion
+	 */
+	initOpenIndex?: number[];
+
+	/**
 	 * Alternative to pass in a simple representation of accordion items
 	 */
 	items?: DBAccordionItemInterface[] | string;

--- a/showcases/patternhub/scripts/get-example-file.js
+++ b/showcases/patternhub/scripts/get-example-file.js
@@ -10,6 +10,10 @@ const getOption = (optionName, tsType) => {
 			return `${optionName}={[{key:'test1', value:'Test1'},{key:'test2', value:'Test2'}]}`;
 		}
 
+		if (optionName === 'initOpenIndex') {
+			return `${optionName}={[0,1]}`;
+		}
+
 		if (tsType?.raw.includes('DBSelect')) {
 			return `${optionName}={[{"value":"Test1"},{"value":"Test2"}]}`;
 		}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

It's not possible to have an initial state for open items in accordion.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
