### PR TITLE
fix: removed focus within for hover effect in navigation-item.scss

### DIFF
--- a/packages/components/src/components/navigation-item/navigation-item.scss
+++ b/packages/components/src/components/navigation-item/navigation-item.scss
@@ -58,10 +58,7 @@
 	align-items: center; // Centering the content vertically and horizontally
 
 	&:hover,
-	&:focus-visible,
-	&:has(~ .db-sub-navigation:hover),
-	&:has(~ .db-sub-navigation:focus-visible),
-	&:has(~ .db-sub-navigation:focus-within) {
+	&:has(~ .db-sub-navigation:hover) {
 		@include colors.get-variant-bg-color(0.16);
 	}
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Navigation-Item had hover effect while `focus` was set

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
