### PR TITLE
fix: remove generating icon-fonts from lintstaged

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,6 +1,4 @@
 export default {
-	'packages/foundations/assets/icons/functional/**/*.svg': () =>
-		'npm run update:icon-fonts',
 	'*.md': 'markdownlint -c .markdown-lint.yml',
 	'*.{css,scss}': 'stylelint --fix --allow-empty-input',
 	'*.{js,ts,tsx,jsx,mjs,cjs}': ['prettier --write', 'xo --fix'],


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

- `lintstaged` is triggered even when resolving a merge conflict
- this will trigger the `generate-icon-fonts` if new icons are added
- it isn't necessary to trigger the generation again -> so we shouldn't run the generation process

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
