### PR TITLE
docs(@db-ui/ngx-components): change term to content projection instead of slot

### DIFF
--- a/packages/components/src/components/accordion-item/docs/Angular.md
+++ b/packages/components/src/components/accordion-item/docs/Angular.md
@@ -18,7 +18,7 @@ import { DBAccordionItemModule } from '@db-ui/ngx-components';
 
 ### Use component
 
-#### With Slots
+#### With Content Projection
 
 ```html app.component.html
 <!-- app.component.html -->

--- a/showcases/angular-showcase/src/app/components/default.component.html
+++ b/showcases/angular-showcase/src/app/components/default.component.html
@@ -1,4 +1,4 @@
-<!-- TODO: Slots not working for nested components? -> Had to copy paste variant-cards... -->
+<!-- TODO: Content Projection not working for nested components? -> Had to copy paste variant-cards... -->
 <db-code-docs
 	*ngIf="variantRef"
 	class="variants-card"


### PR DESCRIPTION
The term `slot` is typically not used in the angular world. It's called `content projection` here.
see: https://angular.dev/guide/components/content-projection

closes #1498

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
