### PR TITLE
feat: auto-determine nav item active state

### DIFF
--- a/packages/components/src/components/main-navigation/docs/Angular.md
+++ b/packages/components/src/components/main-navigation/docs/Angular.md
@@ -11,7 +11,10 @@ import { DBMainNavigation } from '@db-ui/ngx-components';
 @Component({
   // ...
   standalone: true,
-  imports: [..., DBMainNavigation],
+  imports: [
+	// ...,
+    DBMainNavigation
+  ],
   // ...
 })
 ```
@@ -57,6 +60,75 @@ import { DBMainNavigation } from '@db-ui/ngx-components';
 	<db-navigation-item [disabled]="true">
 		<ng-container *dbNavigationContent>
 			<a href="#">Navi-Item 3</a>
+		</ng-container>
+	</db-navigation-item>
+</db-main-navigation>
+```
+
+### Angular Router and active state handling
+
+You can set the property `active` to a boolean value as in the example above.
+It will cause the navigation item to displayed in active style and implicitly
+set `aria-current="page"` to the list element.
+
+The component will also check for child element set to `aria-current="page"`.
+Such elements are also displayed in active state.
+This makes the component [integration with the Angular Router](https://angular.dev/best-practices/a11y#active-links-identification) way more elegant
+compared to the first variant.
+
+The component first needs to import the `RouterLink` and `RouterLinkActive` directives.
+
+```ts app.component.ts
+// app.component.ts
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { DBMainNavigation } from '@db-ui/ngx-components';
+
+@Component({
+  // ...
+  standalone: true,
+  imports: [
+	// ...
+	RouterLink,
+	RouterLinkActive,
+	DBMainNavigation
+  ],
+  // ...
+})
+```
+
+Now you can use the Angular Routers `routerLink` directive to define your targets.
+The active style is automatically set once an item receives the `aria-current="page"` attribute.
+
+```html app.component.html
+<!-- app.component.html -->
+
+<db-main-navigation>
+	<db-navigation-item>
+		<ng-container *dbNavigationContent>
+			<a
+				routerLink="/"
+				ariaCurrentWhenActive="page"
+				[routerLinkActiveOptions]="{ exact: true }"
+			>
+				Home
+			</a>
+		</ng-container>
+	</db-navigation-item>
+	<db-navigation-item>
+		<ng-container *dbNavigationContent> Demo Pages </ng-container>
+		<ng-container sub-navigation>
+			<db-navigation-item>
+				<ng-container *dbNavigationContent>
+					<a routerLink="/demo/1" ariaCurrentWhenActive="page">
+						Demo Page 1
+					</a>
+				</ng-container>
+				<ng-container *dbNavigationContent>
+					<a routerLink="/demo/2" ariaCurrentWhenActive="page">
+						Demo Page 2
+					</a>
+				</ng-container>
+			</db-navigation-item>
 		</ng-container>
 	</db-navigation-item>
 </db-main-navigation>

--- a/packages/components/src/components/main-navigation/docs/Vue.md
+++ b/packages/components/src/components/main-navigation/docs/Vue.md
@@ -41,3 +41,46 @@ import { DBMainNavigation, DBNavigationItem } from "@db-ui/v-components";
 	</DBMainNavigation>
 </template>
 ```
+
+### Vue Router and active state handling
+
+You can set the property `active` to a boolean value as in the example above.
+It will cause the navigation item to displayed in active style and implicitly
+set `aria-current="page"` to the list element.
+
+The component will also check for child element set to `aria-current="page"`.
+Such elements are also displayed in active state.
+This makes the component [integration with the Vue Router](https://router.vuejs.org/api/interfaces/RouterLinkProps.html#ariaCurrentValue) way more elegant
+compared to the first variant.
+
+Now you can use Vue Routers `RouterLink` component to define your targets.
+The active style is automatically set once an item receives the `aria-current="page"` attribute.
+
+```vue App.vue
+<!-- App.vue -->
+<script>
+import { DBMainNavigation, DBNavigationItem } from "@db-ui/v-components";
+</script>
+
+<template>
+	<DBMainNavigation>
+		<DBNavigationItem>
+			<RouterLink to="/" ariaCurrentValue="page">Home</RouterLink>
+		</DBNavigationItem>
+		<DBNavigationItem>
+			<template> Demo Pages </template>
+			<template #sub-navigation>
+				<DBNavigationItem>
+					<RouterLink to="/demo/1" ariaCurrentValue="page">
+						Demo Page 1
+					</RouterLink>
+
+					<RouterLink to="/demo/2" ariaCurrentValue="page">
+						Demo Page 2
+					</RouterLink>
+				</DBNavigationItem>
+			</template>
+		</DBNavigationItem>
+	</DBMainNavigation>
+</template>
+```

--- a/packages/components/src/components/main-navigation/main-navigation.scss
+++ b/packages/components/src/components/main-navigation/main-navigation.scss
@@ -13,6 +13,10 @@
 		inline-size: auto;
 	}
 
+	.db-navigation-item:has([aria-current="page"]):first-of-type button {
+		font-weight: 700;
+	}
+
 	& > menu {
 		display: flex;
 		flex-direction: column;
@@ -82,6 +86,17 @@
 						}
 					}
 				}
+			}
+		}
+	}
+
+	:has(.db-navigation-item [aria-current="page"]) {
+		// add puls for main-navigation items
+		@extend %show-db-puls;
+
+		menu {
+			&::after {
+				display: none;
 			}
 		}
 	}

--- a/packages/components/src/components/navigation-item/navigation-item.scss
+++ b/packages/components/src/components/navigation-item/navigation-item.scss
@@ -62,7 +62,8 @@
 		@include colors.get-variant-bg-color(0.16);
 	}
 
-	&:active {
+	&:active,
+	:has([aria-current="page"]) {
 		@include colors.get-variant-bg-color(0.24);
 	}
 }
@@ -104,7 +105,8 @@
 		}
 	}
 
-	&[aria-current="page"] {
+	&[aria-current="page"],
+	[aria-current="page"] {
 		font-weight: 700;
 	}
 

--- a/showcases/angular-showcase/src/app/nav-item/nav-item.component.html
+++ b/showcases/angular-showcase/src/app/nav-item/nav-item.component.html
@@ -1,18 +1,21 @@
 @if (navItem) {
-	<db-navigation-item
-		[backButtonText]="getBackButtonText()"
-		[active]="isActive()"
-	>
+	<db-navigation-item [backButtonText]="getBackButtonText()">
 		@if (navItem.subNavigation) {
 			<ng-container sub-navigation>
 				@for (item of navItem.subNavigation; track item.label) {
-					<app-nav-item [navItem]="item"> </app-nav-item>
+					<app-nav-item [navItem]="item" />
 				}
 			</ng-container>
 		}
 		<ng-container *dbNavigationContent>
 			@if (navItem.component) {
-				<a [routerLink]="navItem.path" queryParamsHandling="merge">
+				<a
+					[routerLink]="navItem.path"
+					[routerLinkActiveOptions]="{ exact: true }"
+					ariaCurrentWhenActive="page"
+					routerLinkActive="active"
+					queryParamsHandling="merge"
+				>
 					{{ navItem.label }}
 				</a>
 			}

--- a/showcases/angular-showcase/src/app/nav-item/nav-item.component.ts
+++ b/showcases/angular-showcase/src/app/nav-item/nav-item.component.ts
@@ -1,4 +1,4 @@
-import { Router, RouterLink } from '@angular/router';
+import { RouterLink, RouterLinkActive } from '@angular/router';
 import { Component, Input } from '@angular/core';
 import { NavItem } from '../utils/navigation-item';
 import { NavigationContentDirective } from '../../../../../output/angular/src/components/navigation-item/NavigationContent.directive';
@@ -7,17 +7,16 @@ import { DBNavigationItem } from '../../../../../output/angular/src/components/n
 @Component({
 	selector: 'app-nav-item',
 	templateUrl: './nav-item.component.html',
-	imports: [RouterLink, DBNavigationItem, NavigationContentDirective],
+	imports: [
+		RouterLink,
+		RouterLinkActive,
+		DBNavigationItem,
+		NavigationContentDirective
+	],
 	standalone: true
 })
 export class NavItemComponent {
 	@Input({ required: true }) navItem!: NavItem;
-	constructor(private readonly router: Router) {}
-
-	isActive = () =>
-		this.navItem.path === ''
-			? this.router.url === '/'
-			: this.router.url.includes(this.navItem.path);
 
 	getBackButtonText = () => {
 		return `Back to ${this.navItem.label}`;

--- a/showcases/vue-showcase/src/NavItemComponent.vue
+++ b/showcases/vue-showcase/src/NavItemComponent.vue
@@ -1,34 +1,24 @@
 <script setup lang="ts">
-import {
-	DBNavigationItem,
-	DBSubNavigation
-} from "../../../output/vue/vue3/src";
+import { DBNavigationItem } from "../../../output/vue/vue3/src";
 import { NavItem } from "./utils/navigation-items";
-import { useRoute } from "vue-router";
 
 defineProps<{
 	navItem?: NavItem;
 }>();
-
-const route = useRoute();
-
-const isActive = (navItem: NavItem) =>
-	navItem.path !== "/"
-		? route.path.includes(navItem.path)
-		: route.path === "/";
 </script>
 
 <template>
-	<DBNavigationItem
-		:backButtonText="`Back to ${navItem.label}`"
-		:active="isActive(navItem)"
-	>
+	<DBNavigationItem :backButtonText="`Back to ${navItem.label}`">
 		<template v-if="navItem.subNavigation" v-slot:sub-navigation>
 			<template v-for="item of navItem.subNavigation">
 				<NavItemComponent :navItem="item"></NavItemComponent>
 			</template>
 		</template>
-		<router-link v-if="navItem.component" :to="navItem.path">
+		<router-link
+			v-if="navItem.component"
+			:to="navItem.path"
+			ariaCurrentValue="page"
+		>
 			{{ navItem.label }}
 		</router-link>
 		<template v-if="!navItem.component">{{ navItem.label }}</template>


### PR DESCRIPTION
It will make the the `db-navigation-item`'s `active` prop  optional. It highlights an active link element with it's children. It still works as before but in addition it checks for child elements. They styles like active elements when having the `aria-current` attr set. It allows to use framework build-in aria-current mechanisms.

closes #2200

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
