### PR TITLE
fix: issue with drawer closing on every key

### DIFF
--- a/packages/components/src/components/drawer/drawer.lite.tsx
+++ b/packages/components/src/components/drawer/drawer.lite.tsx
@@ -33,7 +33,7 @@ export default function DBDrawer(props: DBDrawerProps) {
 					props.backdrop !== 'none')
 			) {
 				if (props.onClose) {
-					props.onClose();
+					props.onClose(event);
 				}
 			}
 		},

--- a/packages/components/src/components/drawer/model.ts
+++ b/packages/components/src/components/drawer/model.ts
@@ -9,17 +9,21 @@ import {
 
 export interface DBDrawerDefaultProps {
 	/**
-	 * The direction attribute changes the position & animation of the drawer.
-	 * E. g. "left" slides from left screen border to the right.
-	 */
-	direction?: 'left' | 'right' | 'up' | 'down';
-
-	/**
 	 * The backdrop attribute changes the opacity of the backdrop.
 	 * The backdrop 'none' will use `dialog.show()` instead of `dialog.showModal()`
 	 */
 	backdrop?: 'strong' | 'weak' | 'invisible' | 'none';
 
+	/**
+	 * The direction attribute changes the position & animation of the drawer.
+	 * E.g. "left" slides from left screen border to the right.
+	 */
+	direction?: 'left' | 'right' | 'up' | 'down';
+
+	/**
+	 * React specific to change the header of the drawer.
+	 */
+	drawerHeader?: unknown;
 	/**
 	 * The open attribute opens or closes the drawer based on the state.
 	 */
@@ -29,10 +33,6 @@ export interface DBDrawerDefaultProps {
 	 * The "end" depends on which direction you use.
 	 */
 	rounded?: boolean;
-	/**
-	 * React specific to change the header of the drawer.
-	 */
-	drawerHeader?: unknown;
 	/**
 	 * The @dependabot recreate attribute changes the padding inside the drawer.
 	 */

--- a/packages/components/src/shared/model.ts
+++ b/packages/components/src/shared/model.ts
@@ -396,7 +396,7 @@ export type CloseEventProps = {
 	/**
 	 * Function to handle button click (close).
 	 */
-	onClose?: () => void;
+	onClose?: (event?: any) => void;
 };
 
 export type CloseEventState = {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

closes #2594

- Handle backdrop click with additional `event.type===click`
- Pass `event` to `onClose` for user to check which event was fired

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
