### PR TITLE
fix: missing alignment property (center)

### DIFF
--- a/packages/components/src/shared/model.ts
+++ b/packages/components/src/shared/model.ts
@@ -434,7 +434,7 @@ export type CloseEventState = {
 	handleClose?: (event: any) => void;
 };
 
-export const AlignmentList = ['start'] as const;
+export const AlignmentList = ['start', 'center'] as const;
 export type AlignmentType = (typeof AlignmentList)[number];
 export type AlignmentProps = {
 	/**


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The `center` string literal was missing for `alignment` for `DBTabs` 

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
