### PR TITLE
fix: issue with tailwind tokens causing esbuild warning

### DIFF
--- a/packages/foundations/tailwind/tailwind-tokens.json
+++ b/packages/foundations/tailwind/tailwind-tokens.json
@@ -76,15 +76,23 @@
 			"var(--db-type-body-font-size-md)",
 			"var(--db-type-body-line-height-md)"
 		],
+		"body-3xs": [
+			"var(--db-type-body-font-size-3xs)",
+			"var(--db-type-body-line-height-3xs)"
+		],
+		"body-2xs": [
+			"var(--db-type-body-font-size-2xs)",
+			"var(--db-type-body-line-height-2xs)"
+		],
+		"body-2xl": [
+			"var(--db-type-body-font-size-2xl)",
+			"var(--db-type-body-line-height-2xl)"
+		],
+		"body-3xl": [
+			"var(--db-type-body-font-size-3xl)",
+			"var(--db-type-body-line-height-3xl)"
+		],
 		"body": {
-			"3xs": [
-				"var(--db-type-body-font-size-3xs)",
-				"var(--db-type-body-line-height-3xs)"
-			],
-			"2xs": [
-				"var(--db-type-body-font-size-2xs)",
-				"var(--db-type-body-line-height-2xs)"
-			],
 			"xs": [
 				"var(--db-type-body-font-size-xs)",
 				"var(--db-type-body-line-height-xs)"
@@ -104,25 +112,25 @@
 			"xl": [
 				"var(--db-type-body-font-size-xl)",
 				"var(--db-type-body-line-height-xl)"
-			],
-			"2xl": [
-				"var(--db-type-body-font-size-2xl)",
-				"var(--db-type-body-line-height-2xl)"
-			],
-			"3xl": [
-				"var(--db-type-body-font-size-3xl)",
-				"var(--db-type-body-line-height-3l)"
 			]
 		},
+		"head-3xs": [
+			"var(--db-type-headline-font-size-3xs)",
+			"var(--db-type-headline-line-height-3xs)"
+		],
+		"head-2xs": [
+			"var(--db-type-headline-font-size-2xs)",
+			"var(--db-type-headline-line-height-2xs)"
+		],
+		"head-2xl": [
+			"var(--db-type-headline-font-size-2xl)",
+			"var(--db-type-headline-line-height-2xl)"
+		],
+		"head-3xl": [
+			"var(--db-type-headline-font-size-3xl)",
+			"var(--db-type-headline-line-height-3xl)"
+		],
 		"head": {
-			"3xs": [
-				"var(--db-type-headline-font-size-3xs)",
-				"var(--db-type-headline-line-height-3xs)"
-			],
-			"2xs": [
-				"var(--db-type-headline-font-size-2xs)",
-				"var(--db-type-headline-line-height-2xs)"
-			],
 			"xs": [
 				"var(--db-type-headline-font-size-xs)",
 				"var(--db-type-headline-line-height-xs)"
@@ -142,14 +150,6 @@
 			"xl": [
 				"var(--db-type-headline-font-size-xl)",
 				"var(--db-type-headline-line-height-xl)"
-			],
-			"2xl": [
-				"var(--db-type-headline-font-size-2xl)",
-				"var(--db-type-headline-line-height-2xl)"
-			],
-			"3xl": [
-				"var(--db-type-headline-font-size-3xl)",
-				"var(--db-type-headline-line-height-3l)"
 			]
 		}
 	},


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

closes https://github.com/db-ui/theme-builder/issues/329

Esbuild was not able to append keys in the `tailwind-token.json` which start with a number like `3xs` 

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
