### PR TITLE
fix: remove global link style from DBCard

### DIFF
--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -9,10 +9,6 @@
 	display: flex;
 	flex-direction: column;
 
-	> a {
-		text-decoration: none;
-	}
-
 	&[data-spacing="medium"] {
 		padding: variables.$db-spacing-fixed-md;
 	}


### PR DESCRIPTION
## Proposed changes

Currently Links do not have a text decoration (underline) because of this global style

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

