### PR TITLE
fix: static tag color to align with design

### DIFF
--- a/packages/components/src/styles/_tag-components.scss
+++ b/packages/components/src/styles/_tag-components.scss
@@ -16,7 +16,7 @@ $interactive-selectors: "label, button:not(.db-tab-remove-button), a";
 }
 
 @mixin get-tag-colors() {
-	background-color: colors.$db-current-color-bg-lvl-1-enabled;
+	background-color: colors.$db-current-color-bg-lvl-3-enabled;
 
 	&[data-emphasis="strong"] {
 		@extend %set-adaptive-strong-tag;
@@ -24,7 +24,7 @@ $interactive-selectors: "label, button:not(.db-tab-remove-button), a";
 
 	@each $name in colors.$variant-colors {
 		&[data-semantic="#{$name}"] {
-			@extend %db-#{$name}-bg-lvl-1;
+			@extend %db-#{$name}-bg-lvl-3;
 
 			&[data-emphasis="strong"] {
 				@extend %db-#{$name}-contrast-high;


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Static tag had wrong bg-lvl (1), but needs bg-lvl-3

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
