### PR TITLE
fix: adds optional codeFileName field to components example data

### DIFF
--- a/showcases/react-showcase/src/components/data.ts
+++ b/showcases/react-showcase/src/components/data.ts
@@ -8,7 +8,10 @@ export const getVariants = (
 ): ReactDefaultComponentVariants[] =>
 	defaultComponentVariants.map((variant, variantIndex) => ({
 		...variant,
-		SlotCode: codeSlots?.[variant.name.replaceAll(' ', '')],
+		SlotCode:
+			codeSlots?.[
+				variant.codeFileName ?? variant.name.replaceAll(' ', '')
+			],
 		examples: variant.examples.map((example, exampleIndex) => ({
 			...example,
 			example: getExample({

--- a/showcases/shared/default-component-data.ts
+++ b/showcases/shared/default-component-data.ts
@@ -19,6 +19,7 @@ export type DefaultComponentExample = {
 
 export type DefaultComponentVariants = {
 	name: string;
+	codeFileName?: string;
 	children?: DefaultComponentExample[];
 	examples: DefaultComponentExample[];
 	color?: string;

--- a/showcases/shared/notification.json
+++ b/showcases/shared/notification.json
@@ -155,6 +155,7 @@
 	},
 	{
 		"name": "Content - Variant:Docked",
+		"codeFileName": "ContentVariantDocked",
 		"examples": [
 			{
 				"name": "Text",
@@ -279,6 +280,7 @@
 	},
 	{
 		"name": "Content - Variant:Standalone",
+		"codeFileName": "ContentVariantStandalone",
 		"examples": [
 			{
 				"name": "Text",
@@ -411,6 +413,7 @@
 	},
 	{
 		"name": "Content - Variant:Overlay",
+		"codeFileName": "ContentVariantOverlay",
 		"examples": [
 			{
 				"name": "Text",


### PR DESCRIPTION
## Proposed changes

adds optional codeFileName field to components example data, to include all code examples to patternhub

fixes #2863

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
