### PR TITLE
feat: adds text-wrap balance to headlines h1 - h6

### DIFF
--- a/packages/foundations/scss/init/default-fonts.scss
+++ b/packages/foundations/scss/init/default-fonts.scss
@@ -20,6 +20,7 @@ $headlines: (
 :is(h1, h2, h3, h4, h5, h6) {
 	font-family: var(--db-font-family-head);
 	font-weight: 700;
+	text-wrap: balance;
 
 	&[data-variant="light"] {
 		font-weight: 300;


### PR DESCRIPTION
## Proposed changes

adds text-wrap balance to headlines h1 - h6
resolves #896

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
