### PR TITLE
refactor: overwrite star for screenreader output

### DIFF
--- a/packages/components/src/styles/_form-components.scss
+++ b/packages/components/src/styles/_form-components.scss
@@ -267,9 +267,7 @@ $input-valid-types: "color", "date", "datetime-local", "email", "file", "hidden"
 			&::after {
 				content: "*";
 				// Hiding asterisk from screenreaders, https://www.w3.org/TR/css-content-3/#alt
-				@supports (content: ""/"") {
-					content: "*" / "";
-				}
+				content: "*" / "";
 
 				padding-inline-start: variables.$db-spacing-fixed-2xs;
 			}

--- a/packages/components/src/styles/_form-components.scss
+++ b/packages/components/src/styles/_form-components.scss
@@ -268,7 +268,6 @@ $input-valid-types: "color", "date", "datetime-local", "email", "file", "hidden"
 				content: "*";
 				// Hiding asterisk from screenreaders, https://www.w3.org/TR/css-content-3/#alt
 				content: "*" / "";
-
 				padding-inline-start: variables.$db-spacing-fixed-2xs;
 			}
 		}

--- a/packages/components/src/styles/_form-components.scss
+++ b/packages/components/src/styles/_form-components.scss
@@ -266,6 +266,11 @@ $input-valid-types: "color", "date", "datetime-local", "email", "file", "hidden"
 		label {
 			&::after {
 				content: "*";
+				// Hiding asterisk from screenreaders, https://www.w3.org/TR/css-content-3/#alt
+				@supports (content: ""/"") {
+					content: "*" / "";
+				}
+
 				padding-inline-start: variables.$db-spacing-fixed-2xs;
 			}
 		}

--- a/showcases/screen-reader/__snapshots__/windows/chromium/DBInput-required-1.txt
+++ b/showcases/screen-reader/__snapshots__/windows/chromium/DBInput-required-1.txt
@@ -1,1 +1,1 @@
-["Label star, edit, required, Required, blank","T. e. s. t. TODO: Add a valid Message","Test selected","blank. Please fill out this field.. unselected","T. e. s. t. TODO: Add a valid Message"]
+["Label, edit, required, Required, blank","T. e. s. t. TODO: Add a valid Message","Test selected","blank. Please fill out this field.. unselected","T. e. s. t. TODO: Add a valid Message"]


### PR DESCRIPTION
## Proposed changes

We could set an empty alternative text for the inserted star on required form fields as we don't want to output that glyph e.g. for screenreader users, because we're already setting the correct state by the `required`-HTML-attribute.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
