### PR TITLE
fix(safari): restored list-style type for VoiceOver screenreader

### DIFF
--- a/packages/components/src/components/tab-item/tab-item.scss
+++ b/packages/components/src/components/tab-item/tab-item.scss
@@ -15,7 +15,7 @@ $tab-border-radius: variables.$db-border-radius-sm;
 .db-tab-item {
 	position: relative;
 	display: inline-flex;
-	list-style-type: none;
+	list-style-type: "";
 	border-radius: $tab-border-radius;
 
 	&:has(input:disabled) {

--- a/packages/foundations/scss/init/required.scss
+++ b/packages/foundations/scss/init/required.scss
@@ -119,7 +119,7 @@ nav,
 [role="navigation"] {
 	ol,
 	ul {
-		list-style: none;
+		list-style-type: "";
 		margin: 0;
 		padding: 0;
 	}

--- a/showcases/showcase-styles.css
+++ b/showcases/showcase-styles.css
@@ -1,6 +1,6 @@
 /* Styles for the showcases */
 .desktop-navigation ul {
-	list-style-type: none;
+	list-style-type: "";
 	display: flex;
 }
 


### PR DESCRIPTION
## Proposed changes

Resolves https://github.com/db-ui/mono/issues/3079

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
