### PR TITLE
fix: simplification for `@db-ui/gif` parameters

### DIFF
--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -32,7 +32,7 @@
     "copy-normalize": "cpr ../../node_modules/@csstools/normalize.css/normalize.css scss/_normalize.scss -o",
     "copy:scss": "cpr scss build/scss -o",
     "dev": "vite --open",
-    "generate:icon-fonts": "npx --no @db-ui/gif -- --src ./assets/icons/functional --variants filled inverted --fontName db-ux --withSizes true --debug true",
+    "generate:icon-fonts": "gif --src ./assets/icons/functional --variants filled inverted --fontName db-ux --withSizes true --debug true",
     "prepare": "npm run copy-normalize",
     "regenerate:screenshots": "npx playwright test -c ./test/playwright.config.mjs --update-snapshots",
     "start": "nodemon --config nodemon.json",

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -32,7 +32,7 @@
     "copy-normalize": "cpr ../../node_modules/@csstools/normalize.css/normalize.css scss/_normalize.scss -o",
     "copy:scss": "cpr scss build/scss -o",
     "dev": "vite --open",
-    "generate:icon-fonts": "npx --no @db-ui/gif --src ./assets/icons/functional --variants filled inverted --fontName db-ux --withSizes true --debug true",
+    "generate:icon-fonts": "npx --no @db-ui/gif -- --src ./assets/icons/functional --variants filled inverted --fontName db-ux --withSizes true --debug true",
     "prepare": "npm run copy-normalize",
     "regenerate:screenshots": "npx playwright test -c ./test/playwright.config.mjs --update-snapshots",
     "start": "nodemon --config nodemon.json",


### PR DESCRIPTION
## Proposed changes

currently we haven't separated `npx` and `@db-ui/gif` parameters correctly. ~That for we need to add `--` accordingly.~

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
