### PR TITLE
fix(version switcher): displaying `latest` entry

### DIFF
--- a/showcases/patternhub/components/version-switcher/version-switcher.tsx
+++ b/showcases/patternhub/components/version-switcher/version-switcher.tsx
@@ -90,11 +90,7 @@ const VersionSwitcher = () => {
 				);
 
 			// `latest` isn't a branch, but only existing within gh-pages
-			tags.push('latest');
-			/* eslint-disable-next-line no-console */
-			console.log('branches', branches);
-			/* eslint-disable-next-line no-console */
-			console.log('tags', tags);
+			tags.unshift('latest');
 
 			setCurrentBranch(branches);
 			setCurrentBranch(tags);

--- a/showcases/patternhub/components/version-switcher/version-switcher.tsx
+++ b/showcases/patternhub/components/version-switcher/version-switcher.tsx
@@ -88,6 +88,10 @@ const VersionSwitcher = () => {
 					(branch) =>
 						branch !== 'gh-pages' && !branch.includes('dependabot')
 				);
+
+			// `latest` isn't a branch, but only existing within gh-pages
+			tags.push('latest');
+
 			setCurrentBranch(branches);
 			setCurrentBranch(tags);
 			setGroupByTagsBranches(tags, branches);

--- a/showcases/patternhub/components/version-switcher/version-switcher.tsx
+++ b/showcases/patternhub/components/version-switcher/version-switcher.tsx
@@ -91,6 +91,10 @@ const VersionSwitcher = () => {
 
 			// `latest` isn't a branch, but only existing within gh-pages
 			tags.push('latest');
+			/* eslint-disable-next-line no-console */
+			console.log('branches', branches);
+			/* eslint-disable-next-line no-console */
+			console.log('tags', tags);
 
 			setCurrentBranch(branches);
 			setCurrentBranch(tags);


### PR DESCRIPTION
## Proposed changes

The `latest` entry isn't getting displayed within the version switcher at the moment.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
