### PR TITLE
fix(a11y): allow labels to be clickable

### DIFF
--- a/packages/components/src/styles/_form-components.scss
+++ b/packages/components/src/styles/_form-components.scss
@@ -336,7 +336,6 @@ $input-valid-types: "color", "date", "datetime-local", "email", "file", "hidden"
 		@extend %db-overwrite-font-size-xs;
 
 		padding-block-end: variables.$db-spacing-fixed-xs;
-		pointer-events: none;
 		cursor: text;
 		max-inline-size: 25ch;
 		text-overflow: ellipsis;


### PR DESCRIPTION
## Proposed changes

I've noticed that the input form element label is not clickable. This means that its not possible to click on the label to focus on the input element. Is this something that was omitted or something I missed?
Maybe there are other form elements where pointer-events for labels are disabled, e.g. text-area.

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)


