### PR TITLE
chore: removed obsolete declaration

### DIFF
--- a/packages/components/src/styles/_form-components.scss
+++ b/packages/components/src/styles/_form-components.scss
@@ -337,7 +337,6 @@ $input-valid-types: "color", "date", "datetime-local", "email", "file", "hidden"
 
 		padding-block-end: variables.$db-spacing-fixed-xs;
 		pointer-events: none;
-		cursor: text;
 		max-inline-size: 25ch;
 		text-overflow: ellipsis;
 		white-space: nowrap;


### PR DESCRIPTION
## Proposed changes

Removed obsolete CSS declaration. It's not clear why we would need to set a specific cursor and couldn't stick with the browsers default (maybe this was related to the declaration we've removed with https://github.com/db-ui/mono/pull/3462).

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
