### PR TITLE
docs: changed from webpack to its successor rollup

### DIFF
--- a/output/angular/README.md
+++ b/output/angular/README.md
@@ -30,7 +30,7 @@ Import the styles in `scss` or `css`. Based on your technology the file names co
 
 ```scss styles.scss
 // styles.scss
-@forward "@db-ui/components/build/styles/db-ui-42-webpack";
+@forward "@db-ui/components/build/styles/db-ui-42-rollup";
 ```
 
 </details>

--- a/output/angular/README.md
+++ b/output/angular/README.md
@@ -22,8 +22,8 @@ npm i @db-ui/ngx-components
 Import the styles in `scss` or `css`. Based on your technology the file names could be different.
 
 -   Default (db-ui-42): points to `../assets`
--   Webpack (db-ui-42-webpack): points to `~@db-ui/foundations/assets`
 -   Rollup (db-ui-42-rollup): points to `@db-ui/foundations/assets`
+-   Webpack (db-ui-42-webpack): points to `~@db-ui/foundations/assets`
 
 <details>
   <summary><strong>SCSS</strong></summary>

--- a/output/react/README.md
+++ b/output/react/README.md
@@ -22,8 +22,8 @@ npm i @db-ui/react-components
 Import the styles in scss or css. Based on your technology the file names could be different.
 
 -   Default (db-ui-42): points to `../assets`
--   Webpack (db-ui-42-webpack): points to `~@db-ui/foundations/assets`
 -   Rollup (db-ui-42-rollup): points to `@db-ui/foundations/assets`
+-   Webpack (db-ui-42-webpack): points to `~@db-ui/foundations/assets`
 
 <details>
   <summary><strong>SCSS</strong></summary>

--- a/output/vue/README.md
+++ b/output/vue/README.md
@@ -22,8 +22,8 @@ npm i @db-ui/v-components
 Import the styles in scss or css. Based on your technology the file names could be different.
 
 -   Default (db-ui-42): points to `../assets`
--   Webpack (db-ui-42-webpack): points to `~@db-ui/foundations/assets`
 -   Rollup (db-ui-42-rollup): points to `@db-ui/foundations/assets`
+-   Webpack (db-ui-42-webpack): points to `~@db-ui/foundations/assets`
 
 <details>
   <summary><strong>SCSS</strong></summary>


### PR DESCRIPTION
## Proposed changes

Changed default bundler tool from webpack to rollup, as the later is the successor or the first one.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
