### PR TITLE
style: enable default text-decoration for .db-link

### DIFF
--- a/packages/components/src/styles/_link-components.scss
+++ b/packages/components/src/styles/_link-components.scss
@@ -40,6 +40,7 @@
 	// TODO: We should evaluate whether we could move this declaration to the @font-face declarations even already
 	text-underline-position: from-font;
 	text-decoration-thickness: helpers.px-to-rem($pxValue: 1);
+	text-decoration: underline;
 
 	&:not([data-variant="inline"]) {
 		white-space: nowrap;


### PR DESCRIPTION
## Proposed changes

Default .db-link has no text-decoration: underline.

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

