### PR TITLE
refactor: using local font references again

### DIFF
--- a/packages/foundations/scss/fonts/include.scss
+++ b/packages/foundations/scss/fonts/include.scss
@@ -4,73 +4,88 @@
 	font-family: "DB Screen Sans";
 	font-style: normal;
 	font-weight: 300;
-	src: /* TODO: add those again as soon as the local files got fixed
+	src:
 		local("DB Screen Sans Digital Regular"),
 		local("DB Screen Sans Digital"),
-		local("DB Sans Digital"),*/ url("#{assets-paths.$fonts-path}dbscreensans-digitalregular.woff2")
-		format("woff2");
+		local("DB Sans Digital"),
+		url("#{assets-paths.$fonts-path}dbscreensans-digitalregular.woff2")
+			format("woff2");
 }
 
 @font-face {
 	font-family: "DB Screen Sans";
 	font-style: normal;
 	font-weight: 400;
-	src: /* local("DB Screen Sans Regular"),
+	src:
+		local("DB Screen Sans Regular"),
 		local("DB Screen Sans"),
-		local("DB Sans"),*/ url("#{assets-paths.$fonts-path}dbscreensans-regular.woff2")
-		format("woff2");
+		local("DB Sans"),
+		url("#{assets-paths.$fonts-path}dbscreensans-regular.woff2")
+			format("woff2");
 }
 
 @font-face {
 	font-family: "DB Screen Sans";
 	font-style: normal;
 	font-weight: 500;
-	src: /* local("DB Screen Sans Medium"),
-		local("DB Sans Medium"),*/ url("#{assets-paths.$fonts-path}dbscreensans-medium.woff2")
-		format("woff2");
+	src:
+		local("DB Screen Sans Medium"),
+		local("DB Sans Medium"),
+		url("#{assets-paths.$fonts-path}dbscreensans-medium.woff2")
+			format("woff2");
 }
 
 @font-face {
 	font-family: "DB Screen Sans";
 	font-style: normal;
 	font-weight: 600;
-	src: /* local("DB Screen Sans SemiBold"),
-		local("DB Sans SemiBold"),*/ url("#{assets-paths.$fonts-path}dbscreensans-semibold.woff2")
-		format("woff2");
+	src:
+		local("DB Screen Sans SemiBold"),
+		local("DB Sans SemiBold"),
+		url("#{assets-paths.$fonts-path}dbscreensans-semibold.woff2")
+			format("woff2");
 }
 
 @font-face {
 	font-family: "DB Screen Sans";
 	font-style: normal;
 	font-weight: 700;
-	src: /* local("DB Screen Sans Bold"),
-		local("DB Sans Bold"),*/ url("#{assets-paths.$fonts-path}dbscreensans-bold.woff2")
-		format("woff2");
+	src:
+		local("DB Screen Sans Bold"),
+		local("DB Sans Bold"),
+		url("#{assets-paths.$fonts-path}dbscreensans-bold.woff2")
+			format("woff2");
 }
 
 @font-face {
 	font-family: "DB Screen Head";
 	font-style: normal;
 	font-weight: 300;
-	src: /* local("DB Screen Head Light"),
-		local("DB Head Light"),*/ url("#{assets-paths.$fonts-path}dbscreenhead-light.woff2")
-		format("woff2");
+	src:
+		local("DB Screen Head Light"),
+		local("DB Head Light"),
+		url("#{assets-paths.$fonts-path}dbscreenhead-light.woff2")
+			format("woff2");
 }
 
 @font-face {
 	font-family: "DB Screen Head";
 	font-style: normal;
 	font-weight: 400;
-	src: /* local("DB Screen Head"),
-		local("DB Head"),*/ url("#{assets-paths.$fonts-path}dbscreenhead-regular.woff2")
-		format("woff2");
+	src:
+		local("DB Screen Head"),
+		local("DB Head"),
+		url("#{assets-paths.$fonts-path}dbscreenhead-regular.woff2")
+			format("woff2");
 }
 
 @font-face {
 	font-family: "DB Screen Head";
 	font-style: normal;
 	font-weight: 900;
-	src: /* local("DB Screen Head Black"),
-		local("DB Head Black"),*/ url("#{assets-paths.$fonts-path}dbscreenhead-black.woff2")
-		format("woff2");
+	src:
+		local("DB Screen Head Black"),
+		local("DB Head Black"),
+		url("#{assets-paths.$fonts-path}dbscreenhead-black.woff2")
+			format("woff2");
 }


### PR DESCRIPTION
## Proposed changes

Let's activate the local references again as soon as the local fonts are repaired.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
