### PR TITLE
fix: replaced JavaScript selector

### DIFF
--- a/packages/components/src/components/tabs/tabs.lite.tsx
+++ b/packages/components/src/components/tabs/tabs.lite.tsx
@@ -119,7 +119,7 @@ export default function DBTabs(props: DBTabsProps) {
 
 				const tabPanels = Array.from<Element>(
 					ref.querySelectorAll(
-						':is(& > .db-tab-panel, & > db-tab-panel > .db-tab-panel)'
+						':is(:scope > .db-tab-panel, :scope > db-tab-panel > .db-tab-panel)'
 					)
 				);
 				for (const panel of tabPanels) {


### PR DESCRIPTION
## Proposed changes

Resolves https://github.com/db-ui/mono/issues/3528

Whereas `&` would be perfectly fine at this place to be used within CSS, when executing `.querySelector` or `.querySelectorAll` in JavaScript we would need to use [`:scope`](https://drafts.csswg.org/selectors-4/#the-scope-pseudo) instead, that gets it's [scoping root](https://drafts.csswg.org/selectors-4/#scoping-root) by the documents part on which `.querySelector` or `.querySelectorAll` are based on (the `ref` in our case).

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactoring (fix on existing components or architectural decisions)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
