### PR TITLE
fix: incorrect import

### DIFF
--- a/packages/foundations/scripts/migration/index.ts
+++ b/packages/foundations/scripts/migration/index.ts
@@ -1,6 +1,6 @@
 import { globSync } from 'glob';
-import { ReplaceInFileConfig, replaceInFileSync } from 'replace-in-file';
-import type { ReplaceResult } from 'replace-in-file';
+import type { ReplaceInFileConfig, ReplaceResult } from 'replace-in-file';
+import { replaceInFileSync } from 'replace-in-file';
 import type { OptionsType } from '../types';
 import { migrationTypes } from '../data';
 


### PR DESCRIPTION
## Proposed changes

fixed incorrect import as reported within VS Code:
```
'ReplaceInFileConfig' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.ts(1484)
```

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
