### PR TITLE
fix: migration commander error

### DIFF
--- a/packages/migration/src/data.ts
+++ b/packages/migration/src/data.ts
@@ -26,7 +26,7 @@ export const options: ProgrammOptionsType[] = [
 	},
 	{
 		name: 'dryRun',
-		short: 'dry',
+		short: 'd',
 		description: 'prints the output of the command'
 	}
 ];


### PR DESCRIPTION
## Proposed changes

Fixes the following bug within migration package

```shell
npx @db-ui/migration --type=v006_v007 --src=./src      
~/.npm/_npx/f73cec7303872e39/node_modules/commander/lib/option.js:342
      throw new Error(
            ^

Error: option creation failed due to '-dry' in option flags '-dry, --dryRun <dryRun>'
- a short flag is a single dash and a single character
  - either use a single dash and a single character (for a short flag)
  - or use a double dash for a long option (and can have two, like '--ws, --workspace'
```

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
